### PR TITLE
[Feat] Init add post-proc (building regularization)

### DIFF
--- a/paddlers/utils/__init__.py
+++ b/paddlers/utils/__init__.py
@@ -14,6 +14,7 @@
 
 from . import logging
 from . import utils
+from . import postprocs
 from .utils import (seconds_to_hms, get_encoding, get_single_card_bs, dict2str,
                     EarlyStop, norm_path, is_pic, MyEncoder, DisablePrint,
                     Timer, to_data_parallel, scheduler_step)

--- a/paddlers/utils/postprocs/__init__.py
+++ b/paddlers/utils/postprocs/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .regularization import building_regularization

--- a/paddlers/utils/postprocs/regularization.py
+++ b/paddlers/utils/postprocs/regularization.py
@@ -38,18 +38,18 @@ def building_regularization(mask: np.ndarray, W: int=32) -> np.ndarray:
     (https://ieeexplore.ieee.org/document/8933116).
 
     This algorithm has no public code.
-    The implementation refers to original article and this repo: 
+    The implementation procedure refers to original article and this repo: 
     https://github.com/niecongchong/RS-building-regularization
 
-    The implementation procedure is not fully consistent with the article.
+    The implementation is not fully consistent with the article.
 
     Args:
-        mask (np.ndarray): The mask of building.
+        mask (np.ndarray): Mask of building.
         W (int, optional): Minimum threshold in main direction. Default is 32.
             The larger W, the more regular the image, but the worse the image detail.
 
     Returns:
-        np.ndarray: The mask of building after regularized.
+        np.ndarray: Mask of building after regularized.
     """
     # check and pro processing
     mask_shape = mask.shape

--- a/paddlers/utils/postprocs/regularization.py
+++ b/paddlers/utils/postprocs/regularization.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cv2
+import numpy as np
+from .utils import *
+
+S = 32
+
+
+def building_regularization(mask: np.ndarray) -> np.ndarray:
+    """
+    Translate the mask of building into structured mask.
+
+    The original article refers to
+    Wei S, Ji S, Lu M. "Toward Automatic Building Footprint Delineation From Aerial Images Using CNN and Regularization."
+    (https://ieeexplore.ieee.org/document/8933116).
+        
+
+    Args:
+        mask (np.ndarray): The mask of building.
+
+    Returns:
+        np.ndarray: The mask of building after regularized.
+    """
+    # check
+    shapes = mask.shape
+    slens = len(shapes)
+    if slens != 2:
+        mask = (mask[..., 0])
+    clases = np.unique(mask)
+    clens = len(clases)
+    if clens != 2:
+        raise ValueError(
+            "The number of categories in mask must be 2, not {}.".format(clens))
+    mask = np.clip(mask, 0, 1).astype("uint8")  # 0-255 / 0-1 -> 0-1
+    # find contours
+    contours, hierarchys = cv2.findContours(mask, cv2.RETR_TREE,
+                                            cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        raise ValueError("There are no contours.")
+    # coarse
+    hconts = []
+    for contour, hierarchy in zip(contours, hierarchys[0]):
+        area = cv2.contourArea(contour)
+        if area >= S:  #  remove polygons whose area is below a threshold S
+            epsilon = 0.005 * cv2.arcLength(contour, True)
+            contour = cv2.approxPolyDP(contour, epsilon, True)  # DP
+            hconts.append((contour, _get_priority(hierarchy)))
+    return _fill(mask, hconts)  # fill
+
+
+def _get_priority(hierarchy) -> int:
+    print(type(hierarchy))
+    if hierarchy[3] < 0:
+        return 1
+    if hierarchy[2] < 0:
+        return 2
+    return 3
+
+
+def _fill(img, hconts) -> np.ndarray:
+    result = np.zeros_like(img)
+    sorted(hconts, key=lambda x: x[1])
+    for contour, priority in hconts:
+        if priority == 2:
+            cv2.fillPoly(result, [contour], (0, 0, 0))
+        else:
+            cv2.fillPoly(result, [contour], (255, 255, 255))
+    return result

--- a/paddlers/utils/postprocs/regularization.py
+++ b/paddlers/utils/postprocs/regularization.py
@@ -12,57 +12,240 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import cv2
 import numpy as np
-from .utils import *
+from .utils import (calc_distance, calc_angle, calc_azimuth, rotation, line,
+                    intersection, calc_distance_between_lines,
+                    calc_project_in_line)
 
-S = 32
+S = 20
+TD = 3
+D = TD + 1
+
+ALPHA = math.degrees(math.pi / 6)
+BETA = math.degrees(math.pi * 17 / 18)
+DELTA = math.degrees(math.pi / 12)
+THETA = math.degrees(math.pi / 4)
 
 
-def building_regularization(mask: np.ndarray) -> np.ndarray:
+def building_regularization(mask: np.ndarray, W: int=32) -> np.ndarray:
     """
     Translate the mask of building into structured mask.
 
     The original article refers to
     Wei S, Ji S, Lu M. "Toward Automatic Building Footprint Delineation From Aerial Images Using CNN and Regularization."
     (https://ieeexplore.ieee.org/document/8933116).
-        
+
+    This algorithm has no public code.
+    The implementation refers to original article and this repo: 
+    https://github.com/niecongchong/RS-building-regularization
+
+    The implementation procedure is not fully consistent with the article.
 
     Args:
         mask (np.ndarray): The mask of building.
+        W (int, optional): Minimum threshold in main direction. Default is 32.
+            The larger W, the more regular the image, but the worse the image detail.
 
     Returns:
         np.ndarray: The mask of building after regularized.
     """
-    # check
-    shapes = mask.shape
-    slens = len(shapes)
-    if slens != 2:
-        mask = (mask[..., 0])
-    clases = np.unique(mask)
-    clens = len(clases)
-    if clens != 2:
-        raise ValueError(
-            "The number of categories in mask must be 2, not {}.".format(clens))
+    # check and pro processing
+    mask_shape = mask.shape
+    if len(mask_shape) != 2:
+        mask = mask[..., 0]
+    mask = cv2.medianBlur(mask, 5)
+    class_num = len(np.unique(mask))
+    if class_num != 2:
+        _, mask = cv2.threshold(mask, 0, 255, cv2.THRESH_BINARY |
+                                cv2.THRESH_OTSU)
     mask = np.clip(mask, 0, 1).astype("uint8")  # 0-255 / 0-1 -> 0-1
+    mask_shape = mask.shape
     # find contours
     contours, hierarchys = cv2.findContours(mask, cv2.RETR_TREE,
                                             cv2.CHAIN_APPROX_SIMPLE)
     if not contours:
         raise ValueError("There are no contours.")
-    # coarse
-    hconts = []
+    # adjust
+    res_contours = []
     for contour, hierarchy in zip(contours, hierarchys[0]):
-        area = cv2.contourArea(contour)
-        if area >= S:  #  remove polygons whose area is below a threshold S
-            epsilon = 0.005 * cv2.arcLength(contour, True)
-            contour = cv2.approxPolyDP(contour, epsilon, True)  # DP
-            hconts.append((contour, _get_priority(hierarchy)))
-    return _fill(mask, hconts)  # fill
+        contour = _coarse(contour, mask_shape)  # coarse
+        if contour is None:
+            continue
+        contour = _fine(contour, W)  # fine
+        res_contours.append((contour, _get_priority(hierarchy)))
+    result = _fill(mask, res_contours)  # fill
+    result = cv2.morphologyEx(result, cv2.MORPH_OPEN,
+                              cv2.getStructuringElement(cv2.MORPH_RECT,
+                                                        (3, 3)))  # open
+    return result
 
 
-def _get_priority(hierarchy) -> int:
-    print(type(hierarchy))
+def _coarse(contour, img_shape):
+    def _inline_check(point, shape, eps=5):
+        x, y = point[0]
+        iH, iW = shape
+        if x < eps or x > iH - eps or y < eps or y > iW - eps:
+            return False
+        else:
+            return True
+
+    area = cv2.contourArea(contour)
+    # S = 20
+    if area < S:  # remove polygons whose area is below a threshold S
+        return None
+    # D = 0.3 if area < 200 else 1.0
+    # TD = 0.5 if area < 200 else 0.9
+    epsilon = 0.005 * cv2.arcLength(contour, True)
+    contour = cv2.approxPolyDP(contour, epsilon, True)  # DP
+    p_number = contour.shape[0]
+    idx = 0
+    while idx < p_number:
+        last_point = contour[idx - 1]
+        current_point = contour[idx]
+        next_idx = (idx + 1) % p_number
+        next_point = contour[next_idx]
+        # remove edges whose lengths are below a given side length TD
+        # that varies with the area of a building.
+        distance = calc_distance(current_point, next_point)
+        if distance < TD and not _inline_check(next_point, img_shape):
+            contour = np.delete(contour, next_idx, axis=0)
+            p_number -= 1
+            continue
+        # remove over-sharp angles with threshold α.
+        # remove over-smooth angles with threshold β.
+        angle = calc_angle(last_point, current_point, next_point)
+        if (ALPHA > angle or angle > BETA) and _inline_check(current_point,
+                                                             img_shape):
+            contour = np.delete(contour, idx, axis=0)
+            p_number -= 1
+            continue
+        idx += 1
+    if p_number > 2:
+        return contour
+    else:
+        return None
+
+
+def _fine(contour, W):
+    # area = cv2.contourArea(contour)
+    # W = 6 if area < 200 else 8
+    # TD = 0.5 if area < 200 else 0.9
+    # D = TD + 0.3
+    nW = W
+    p_number = contour.shape[0]
+    distance_list = []
+    azimuth_list = []
+    indexs_list = []
+    for idx in range(p_number):
+        current_point = contour[idx]
+        next_idx = (idx + 1) % p_number
+        next_point = contour[next_idx]
+        distance_list.append(calc_distance(current_point, next_point))
+        azimuth_list.append(calc_azimuth(current_point, next_point))
+        indexs_list.append((idx, next_idx))
+    # add the direction of the longest edge to the list of main direction.
+    longest_distance_idx = np.argmax(distance_list)
+    main_direction_list = [azimuth_list[longest_distance_idx]]
+    max_dis = distance_list[longest_distance_idx]
+    if max_dis <= nW:
+        nW = max_dis - 1e-6
+    # Add other edges’ direction to the list of main directions
+    # according to the angle threshold δ between their directions
+    # and directions in the list.
+    for distance, azimuth in zip(distance_list, azimuth_list):
+        for mdir in main_direction_list:
+            abs_dif_ang = abs(mdir - azimuth)
+            if distance > nW and THETA <= abs_dif_ang <= (180 - THETA):
+                main_direction_list.append(azimuth)
+    contour_by_lines = []
+    md_used_list = [main_direction_list[0]]
+    for distance, azimuth, (idx, next_idx) in zip(distance_list, azimuth_list,
+                                                  indexs_list):
+        p1 = contour[idx]
+        p2 = contour[next_idx]
+        pm = (p1 + p2) / 2
+        # find long edges with threshold W that varies with building’s area.
+        if distance > nW:
+            rotate_ang = main_direction_list[0] - azimuth
+            for main_direction in main_direction_list:
+                r_ang = main_direction - azimuth
+                if abs(r_ang) < abs(rotate_ang):
+                    rotate_ang = r_ang
+                    md_used_list.append(main_direction)
+            abs_rotate_ang = abs(rotate_ang)
+            # adjust long edges according to the list and angles.
+            if abs_rotate_ang < DELTA or abs_rotate_ang > (180 - DELTA):
+                rp1 = rotation(p1, pm, rotate_ang)
+                rp2 = rotation(p2, pm, rotate_ang)
+            elif (90 - DELTA) < abs_rotate_ang < (90 + DELTA):
+                rp1 = rotation(p1, pm, rotate_ang - 90)
+                rp2 = rotation(p2, pm, rotate_ang - 90)
+            else:
+                rp1, rp2 = p1, p2
+        # adjust short edges (judged by a threshold θ) according to the list and angles.
+        else:
+            rotate_ang = md_used_list[-1] - azimuth
+            abs_rotate_ang = abs(rotate_ang)
+            if abs_rotate_ang < THETA or abs_rotate_ang > (180 - THETA):
+                rp1 = rotation(p1, pm, rotate_ang)
+                rp2 = rotation(p2, pm, rotate_ang)
+            else:
+                rp1 = rotation(p1, pm, rotate_ang - 90)
+                rp2 = rotation(p2, pm, rotate_ang - 90)
+        # contour_by_lines.extend([rp1, rp2])
+        contour_by_lines.append([rp1[0], rp2[0]])
+    correct_points = np.array(contour_by_lines)
+    # merge (or connect) parallel lines if the distance between
+    # two lines is less than (or larger than) a threshold D.
+    final_points = []
+    final_points.append(correct_points[0][0].reshape([1, 2]))
+    lp_number = correct_points.shape[0] - 1
+    for idx in range(lp_number):
+        next_idx = (idx + 1) if idx < lp_number else 0
+        cur_edge_p1 = correct_points[idx][0]
+        cur_edge_p2 = correct_points[idx][1]
+        next_edge_p1 = correct_points[next_idx][0]
+        next_edge_p2 = correct_points[next_idx][1]
+        L1 = line(cur_edge_p1, cur_edge_p2)
+        L2 = line(next_edge_p1, next_edge_p2)
+        A1 = calc_azimuth([cur_edge_p1], [cur_edge_p2])
+        A2 = calc_azimuth([next_edge_p1], [next_edge_p2])
+        dif_azi = abs(A1 - A2)
+        # find intersection point if not parallel
+        if (90 - DELTA) < dif_azi < (90 + DELTA):
+            point_intersection = intersection(L1, L2)
+            if point_intersection is not None:
+                final_points.append(point_intersection)
+        # move or add lines when parallel
+        elif dif_azi < 1e-6:
+            marg = calc_distance_between_lines(L1, L2)
+            if marg < D:
+                # move
+                point_move = calc_project_in_line(next_edge_p1, cur_edge_p1,
+                                                  cur_edge_p2)
+                final_points.append(point_move)
+                # update next
+                correct_points[next_idx][0] = point_move
+                correct_points[next_idx][1] = calc_project_in_line(
+                    next_edge_p2, cur_edge_p1, cur_edge_p2)
+            else:
+                # add line
+                add_mid_point = (cur_edge_p2 + next_edge_p1) / 2
+                rp1 = calc_project_in_line(add_mid_point, cur_edge_p1,
+                                           cur_edge_p2)
+                rp2 = calc_project_in_line(add_mid_point, next_edge_p1,
+                                           next_edge_p2)
+                final_points.extend([rp1, rp2])
+        else:
+            final_points.extend(
+                [cur_edge_p1[np.newaxis, :], cur_edge_p2[np.newaxis, :]])
+    final_points = np.array(final_points)
+    return final_points
+
+
+def _get_priority(hierarchy):
     if hierarchy[3] < 0:
         return 1
     if hierarchy[2] < 0:
@@ -70,12 +253,12 @@ def _get_priority(hierarchy) -> int:
     return 3
 
 
-def _fill(img, hconts) -> np.ndarray:
+def _fill(img, coarse_conts):
     result = np.zeros_like(img)
-    sorted(hconts, key=lambda x: x[1])
-    for contour, priority in hconts:
+    sorted(coarse_conts, key=lambda x: x[1])
+    for contour, priority in coarse_conts:
         if priority == 2:
-            cv2.fillPoly(result, [contour], (0, 0, 0))
+            cv2.fillPoly(result, [contour.astype(np.int32)], (0, 0, 0))
         else:
-            cv2.fillPoly(result, [contour], (255, 255, 255))
+            cv2.fillPoly(result, [contour.astype(np.int32)], (255, 255, 255))
     return result

--- a/paddlers/utils/postprocs/utils.py
+++ b/paddlers/utils/postprocs/utils.py
@@ -12,44 +12,102 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+import numpy as np
 import math
 
 
-def calc_distance(p1: Tuple[float, float], p2: Tuple[float, float]) -> float:
-    return float(((p1[0] - p2[0])**2 + (p1[1] - p2[1])**2)**0.5)
+def calc_distance(p1: np.ndarray, p2: np.ndarray) -> float:
+    return float(np.sqrt(np.sum(np.power((p1[0] - p2[0]), 2))))
 
 
-def calc_angle(p1: Tuple[float, float],
-               vertex: Tuple[float, float],
-               p2: Tuple[float, float]) -> float:
-    x1, y1 = p1
-    xv, yv = vertex
-    x2, y2 = p2
+def calc_angle(p1: np.ndarray, vertex: np.ndarray, p2: np.ndarray) -> float:
+    x1, y1 = p1[0]
+    xv, yv = vertex[0]
+    x2, y2 = p2[0]
     a = ((xv - x2) * (xv - x2) + (yv - y2) * (yv - y2))**0.5
     b = ((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2))**0.5
     c = ((x1 - xv) * (x1 - xv) + (y1 - yv) * (y1 - yv))**0.5
-    return float(math.degrees(math.acos((b**2 - a**2 - c**2) / (-2 * a * c))))
+    return math.degrees(math.acos((b**2 - a**2 - c**2) / (-2 * a * c)))
 
 
-def calc_azimuth(p1: Tuple[float, float], p2: Tuple[float, float]) -> float:
-    angle = 0.0
-    x1, y1 = p1
-    x2, y2 = p2
-    dx = x2 - x1
-    dy = y2 - y1
-    if x2 == x1:
-        angle = math.pi / 2.0
-        if y2 == y1:
-            angle = 0.0
-        elif y2 < y1:
-            angle = 3.0 * math.pi / 2.0
-    elif x2 > x1 and y2 > y1:
-        angle = math.atan(dx / dy)
-    elif x2 > x1 and y2 < y1:
-        angle = math.pi / 2 + math.atan(-dy / dx)
-    elif x2 < x1 and y2 < y1:
-        angle = math.pi + math.atan(dx / dy)
-    elif x2 < x1 and y2 > y1:
-        angle = 3.0 * math.pi / 2.0 + math.atan(dy / -dx)
-    return float(angle * 180 / math.pi)
+def calc_azimuth(p1: np.ndarray, p2: np.ndarray) -> float:
+    x1, y1 = p1[0]
+    x2, y2 = p2[0]
+    if y1 == y2:
+        return 0.0
+    if x1 == x2:
+        return 90.0
+    elif x1 < x2:
+        if y1 < y2:
+            ang = math.atan((y2 - y1) / (x2 - x1))
+            return math.degrees(ang)
+        else:
+            ang = math.atan((y1 - y2) / (x2 - x1))
+            return 180 - math.degrees(ang)
+    else:  # x1 > x2
+        if y1 < y2:
+            ang = math.atan((y2 - y1) / (x1 - x2))
+            return 180 - math.degrees(ang)
+        else:
+            ang = math.atan((y1 - y2) / (x1 - x2))
+            return math.degrees(ang)
+
+
+def rotation(point: np.ndarray, center: np.ndarray, angle: float) -> np.ndarray:
+    if angle == 0:
+        return point
+    x, y = point[0]
+    cx, cy = center[0]
+    radian = math.radians(abs(angle))
+    if angle > 0:  # clockwise
+        rx = (x - cx) * math.cos(radian) - (y - cy) * math.sin(radian) + cx
+        ry = (x - cx) * math.sin(radian) + (y - cy) * math.cos(radian) + cy
+    else:
+        rx = (x - cx) * math.cos(radian) + (y - cy) * math.sin(radian) + cx
+        ry = (y - cy) * math.cos(radian) - (x - cx) * math.sin(radian) + cy
+    return np.array([[rx, ry]])
+
+
+def line(p1, p2):
+    A = (p1[1] - p2[1])
+    B = (p2[0] - p1[0])
+    C = (p1[0] * p2[1] - p2[0] * p1[1])
+    return A, B, -C
+
+
+def intersection(L1, L2):
+    D = L1[0] * L2[1] - L1[1] * L2[0]
+    Dx = L1[2] * L2[1] - L1[1] * L2[2]
+    Dy = L1[0] * L2[2] - L1[2] * L2[0]
+    if D != 0:
+        x = Dx / D
+        y = Dy / D
+        return np.array([[x, y]])
+    else:
+        return None
+
+
+def calc_distance_between_lines(L1, L2):
+    eps = 1e-16
+    A1, _, C1 = L1
+    A2, B2, C2 = L2
+    new_C1 = C1 / (A1 + eps)
+    new_A2 = 1
+    new_B2 = B2 / (A2 + eps)
+    new_C2 = C2 / (A2 + eps)
+    dist = (np.abs(new_C1 - new_C2)) / (
+        np.sqrt(new_A2 * new_A2 + new_B2 * new_B2) + eps)
+    return dist
+
+
+def calc_project_in_line(point, line_point1, line_point2):
+    eps = 1e-16
+    m, n = point
+    x1, y1 = line_point1
+    x2, y2 = line_point2
+    F = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1)
+    x = (m * (x2 - x1) * (x2 - x1) + n * (y2 - y1) * (x2 - x1) +
+         (x1 * y2 - x2 * y1) * (y2 - y1)) / (F + eps)
+    y = (m * (x2 - x1) * (y2 - y1) + n * (y2 - y1) * (y2 - y1) +
+         (x2 * y1 - x1 * y2) * (x2 - x1)) / (F + eps)
+    return np.array([[x, y]])

--- a/paddlers/utils/postprocs/utils.py
+++ b/paddlers/utils/postprocs/utils.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+import math
+
+
+def calc_distance(p1: Tuple[float, float], p2: Tuple[float, float]) -> float:
+    return float(((p1[0] - p2[0])**2 + (p1[1] - p2[1])**2)**0.5)
+
+
+def calc_angle(p1: Tuple[float, float],
+               vertex: Tuple[float, float],
+               p2: Tuple[float, float]) -> float:
+    x1, y1 = p1
+    xv, yv = vertex
+    x2, y2 = p2
+    a = ((xv - x2) * (xv - x2) + (yv - y2) * (yv - y2))**0.5
+    b = ((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2))**0.5
+    c = ((x1 - xv) * (x1 - xv) + (y1 - yv) * (y1 - yv))**0.5
+    return float(math.degrees(math.acos((b**2 - a**2 - c**2) / (-2 * a * c))))
+
+
+def calc_azimuth(p1: Tuple[float, float], p2: Tuple[float, float]) -> float:
+    angle = 0.0
+    x1, y1 = p1
+    x2, y2 = p2
+    dx = x2 - x1
+    dy = y2 - y1
+    if x2 == x1:
+        angle = math.pi / 2.0
+        if y2 == y1:
+            angle = 0.0
+        elif y2 < y1:
+            angle = 3.0 * math.pi / 2.0
+    elif x2 > x1 and y2 > y1:
+        angle = math.atan(dx / dy)
+    elif x2 > x1 and y2 < y1:
+        angle = math.pi / 2 + math.atan(-dy / dx)
+    elif x2 < x1 and y2 < y1:
+        angle = math.pi + math.atan(dx / dy)
+    elif x2 < x1 and y2 > y1:
+        angle = 3.0 * math.pi / 2.0 + math.atan(dy / -dx)
+    return float(angle * 180 / math.pi)

--- a/paddlers/utils/visualize.py
+++ b/paddlers/utils/visualize.py
@@ -63,7 +63,7 @@ def map_display(mask_path: str,
             - "GeoQ China Community", "GeoQ China Street"  (from http://www.geoq.cn/)
             - "AMAP China"  (from https://www.amap.com/)
             - "TencentMap China"  (from https://map.qq.com/)
-            - "BaiduMaps China"   (from https://map.baidu.com/) {
+            - "BaiduMaps China"  (from https://map.baidu.com/) {
                 It is worked in some cases, but it is not recommended.
             }
 
@@ -71,7 +71,7 @@ def map_display(mask_path: str,
 
         These tileset have been corrected through the public algorithm on the Internet.
         * Please read the relevant terms of use carefully:
-            - GeoQ [GISUNI] (http://geoq.cn/useragreement.html)
+            - GeoQ [GISUNI]  (http://geoq.cn/useragreement.html)
             - AMap [AutoNavi]  (https://wap.amap.com/doc/serviceitem.html)
             - Tencent Map  (https://ugc.map.qq.com/AppBox/Landlord/serveagreement.html)
             - Baidu Map  (https://map.baidu.com/zt/client/service/index.html)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Code refactoring | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | Transforms | Tools | Examples | Docs | Tests | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
初步添加一个建筑物规则化的后处理方法。参考论文 [Toward Automatic Building Footprint Delineation From Aerial Images Using CNNand Regularization](https://ieeexplore.ieee.org/document/8933116)，但该论文没有公开代码，参考原文和找到的一个复现 [RS-building-regularization](https://github.com/niecongchong/RS-building-regularization)尝试做了一下。

这个开源的复现与原文有些不一致，省略了原论文中的一些点，比如有多个主方向等，简化出来的结果过于规则，且不能调整。

这是一张某分割模型得到的结果

![39r](https://user-images.githubusercontent.com/71769312/191969002-623b4288-cc91-4e35-8315-0eb91e250e03.png)

使用开源实现得到的简化后建筑物轮廓为

![all_out](https://user-images.githubusercontent.com/71769312/191969087-bae660dc-d13d-4af1-99ef-0d700fac8b4d.jpg)

参考重新实现的结果为（里面有一些经验参数，有点多我怕不好设置，大多都默认了，保留了一个`w`可以设置，`w`是一个长边可以加入主方向的长度阈值，`w`越大越规则，反之越接近原来的形状）

`w=12`的结果如下

![output_12](https://user-images.githubusercontent.com/71769312/191969641-19b4631a-d98f-4633-bb60-0a3f83dbd7a6.png)

`w=32`的结果如下

![output_32](https://user-images.githubusercontent.com/71769312/191969693-f106cb50-6a35-4852-b0b6-c819b6839548.png)

如果晖哥 @Bobholamovic 有时间可以检查下实现，第一次做这种复现，确实也不确定细节都顾及到了，以及他的一些参数。另外就是这个`postproc`文件夹的位置等等。这个PR可长期讨论和修改。

使用方法

```python
from PIL import Image
import numpy as np
import cv2
from paddlers.utils.postprocs import building_regularization

mask = np.asarray(Image.open("39.png"))
res = building_regularization(mask, W=32)
cv2.imwrite("output.png", res)
```