### PR TITLE
[Fix] Update road connection

### DIFF
--- a/paddlers/utils/postprocs/connection.py
+++ b/paddlers/utils/postprocs/connection.py
@@ -29,7 +29,7 @@ from .utils import prepro_mask, calc_distance
 
 
 def cut_road_connection(mask: np.ndarray,
-                        area_threshold: int = 32,
+                        area_threshold: int=32,
                         line_width: int=6) -> np.ndarray:
     """
     Connecting cut road lines.
@@ -41,12 +41,13 @@ def cut_road_connection(mask: np.ndarray,
     This algorithm has no public code.
     The implementation procedure refers to original article,
     and it is not fully consistent with the article:
-    1. The way to determine the optimal number of clusters k used in k-means clustering is not described in the original article. In this implementation, we use the k that reports the highest silhouette score.
+    1. The way to determine the optimal number of clusters k used in k-means clustering is not described in the original article. 
+        In this implementation, we use the k that reports the highest silhouette score.
     2. We unmark the breakpoints if the angle between the two road extensions is less than 90°.
 
     Args:
         mask (np.ndarray): Mask of road.
-        area_threshold (int, optional): Area threshold of filter connection area. Default is 32.
+        area_threshold (int, optional): Threshold to filter out small connected area. Default is 32.
         line_width (int, optional): Width of the line used for patching. Default is 6.
 
     Returns:

--- a/paddlers/utils/postprocs/utils.py
+++ b/paddlers/utils/postprocs/utils.py
@@ -16,12 +16,12 @@ import numpy as np
 import cv2
 
 
-def prepro_mask(mask: np.ndarray):
+def prepro_mask(mask: np.ndarray, area_threshold: int = 32) -> np.ndarray:
     mask_shape = mask.shape
     if len(mask_shape) != 2:
         mask = mask[..., 0]
     mask = mask.astype("uint8")
-    mask = cv2.medianBlur(mask, 5)
+    mask = _del_small_connection(mask, area_threshold)
     class_num = len(np.unique(mask))
     if class_num != 2:
         _, mask = cv2.threshold(mask, 0, 255, cv2.THRESH_BINARY |
@@ -32,3 +32,15 @@ def prepro_mask(mask: np.ndarray):
 
 def calc_distance(p1: np.ndarray, p2: np.ndarray) -> float:
     return float(np.sqrt(np.sum(np.power((p1[0] - p2[0]), 2))))
+
+
+def _del_small_connection(pred: np.ndarray, threshold: int = 32) -> np.ndarray:
+    result = np.zeros_like(pred)
+    contours, reals = cv2.findContours(pred, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)
+    for contour, real in zip(contours, reals[0]):
+        if real[-1] == -1:  # 没有父轮廓
+            if cv2.contourArea(contour) > threshold:
+                cv2.fillPoly(result, [contour], (1))
+        else:
+            cv2.fillPoly(result, [contour], (0))
+    return result.astype("uint8")

--- a/paddlers/utils/postprocs/utils.py
+++ b/paddlers/utils/postprocs/utils.py
@@ -38,7 +38,7 @@ def _del_small_connection(pred: np.ndarray, threshold: int = 32) -> np.ndarray:
     result = np.zeros_like(pred)
     contours, reals = cv2.findContours(pred, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)
     for contour, real in zip(contours, reals[0]):
-        if real[-1] == -1:  # 没有父轮廓
+        if real[-1] == -1:
             if cv2.contourArea(contour) > threshold:
                 cv2.fillPoly(result, [contour], (1))
         else:

--- a/paddlers/utils/postprocs/utils.py
+++ b/paddlers/utils/postprocs/utils.py
@@ -16,7 +16,7 @@ import numpy as np
 import cv2
 
 
-def prepro_mask(mask: np.ndarray, area_threshold: int = 32) -> np.ndarray:
+def prepro_mask(mask: np.ndarray, area_threshold: int=32) -> np.ndarray:
     mask_shape = mask.shape
     if len(mask_shape) != 2:
         mask = mask[..., 0]
@@ -34,9 +34,10 @@ def calc_distance(p1: np.ndarray, p2: np.ndarray) -> float:
     return float(np.sqrt(np.sum(np.power((p1[0] - p2[0]), 2))))
 
 
-def _del_small_connection(pred: np.ndarray, threshold: int = 32) -> np.ndarray:
+def _del_small_connection(pred: np.ndarray, threshold: int=32) -> np.ndarray:
     result = np.zeros_like(pred)
-    contours, reals = cv2.findContours(pred, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)
+    contours, reals = cv2.findContours(pred, cv2.RETR_TREE,
+                                       cv2.CHAIN_APPROX_NONE)
     for contour, real in zip(contours, reals[0]):
         if real[-1] == -1:
             if cv2.contourArea(contour) > threshold:


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Code refactoring | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | Transforms | Tools | Examples | Docs | Tests | Others ] -->
Others 

### Description
<!-- Describe what this PR does -->
使用道路修复时发现了两个问题，对于下面这张图

![t](https://user-images.githubusercontent.com/71769312/207634293-9f59b08d-55eb-4ff9-80d6-be47e3658478.png)

1. 这张图没有断线，如果调用`cut_road_connection`则会得到一个错误如下。这是由于没有断点，因此聚类得到`labels`为`None`，因此无法循环。修复为在前面进行了判断，当`labels is None`，就直接返回原来的图像。

```
Traceback (most recent call last):
  File "e:\dataFiles\github\PaddleRS\testconn.py", line 8, in <module>
    new_mask = cut_road_connection(mask)
  File "e:\dataFiles\github\PaddleRS\paddlers\utils\postprocs\connection.py", line 57, in cut_road_connection
    match_points = _get_match_points(break_points, labels)
  File "e:\dataFiles\github\PaddleRS\paddlers\utils\postprocs\connection.py", line 91, in _get_match_points
    for point, lab in zip(break_points, labels):
TypeError: 'NoneType' object is not iterable
```

2. 但此时返回的结果依然存在问题，原因在于这张图的路线过细，在预处理中使用了`cv2.medianBlur(mask, 5)`，这会导致不忍直视的结果（路都被平滑了，只剩下交点处有个斑）。因此将这个操作改为了一个遍历并删除小面积联通区的操作，新增了一个可选参数`area_threshold`，默认为32。即小于该面积的联通区视为噪声进行删除。

经过上述两个部分的修改后，这张图片进去就能原封不动的出来了。