### PR TITLE
fix Tensor.numpy()[0] to float(Tensor) to adapt 0D

### DIFF
--- a/paddlers/models/ppdet/modeling/tests/test_yolov3_loss.py
+++ b/paddlers/models/ppdet/modeling/tests/test_yolov3_loss.py
@@ -356,10 +356,7 @@ class TestYolov3LossOp(unittest.TestCase):
             x, t, gtbox, anchor, self.downsample_ratio, self.scale_x_y)
         for k in yolo_loss2:
             self.assertAlmostEqual(
-                yolo_loss1[k].numpy()[0],
-                yolo_loss2[k].numpy()[0],
-                delta=1e-2,
-                msg=k)
+                float(yolo_loss1[k]), float(yolo_loss2[k]), delta=1e-2, msg=k)
 
 
 class TestYolov3LossNoGTScore(TestYolov3LossOp):


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Code refactoring | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | Transforms | Tools | Examples | Docs | Tests | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

有些Tensor正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在升级为0D后，Tensor.numpy()[0] 的写法不再使用，将其改变为 float(Tensor) 的写法，兼容升级前后。
