### PR TITLE
[Fix] Fix setup error about .version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include paddlers/.version

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
         setuptools.find_namespace_packages(include=['paddlers', 'paddlers.*']),
         python_requires='>=3.7',
         setup_requires=['cython', 'numpy'],
+        include_package_data=True,
         install_requires=REQUIRED_PACKAGES,
         classifiers=[
             "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Code refactoring | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | Transforms | Tools | Examples | Docs | Tests | Others ] -->
Setup

### Description
<!-- Describe what this PR does -->
目前使用`setup.py`安装时会忽略`.version`文件从而造成问题。该修复添加了`MANIFEST.in`文件，确保使用`setup.py`时包含`.version`文件。