### PR TITLE
修复使用norm时len(axis)=2且p!=None的情况 

### DIFF
--- a/paddlers/models/ppdet/modeling/assigners/uniform_assigner.py
+++ b/paddlers/models/ppdet/modeling/assigners/uniform_assigner.py
@@ -30,7 +30,7 @@ def batch_p_dist(x, y, p=2):
     """
     x = x.unsqueeze(1)
     diff = x - y
-    return paddle.norm(diff, p=p, axis=list(range(2, diff.dim())))
+    return paddle.linalg.vector_norm(diff, p=p, axis=list(range(2, diff.dim())))
 
 
 @register


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Code refactoring | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | Transforms | Tools | Examples | Docs | Tests | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
norm中len(axis)=2且p!=None时原先计算的是向量范数，norm升级后出现不兼容，现在直接调用paddle.linalg.vector_norm实现相应功能。